### PR TITLE
fix: unable to compile on apple M1 chips

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-07-15"
+channel = "1.68.2"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Like the title says: Needed to upgrade the toolchain to the latest stable release to be able to compile this crate on a Macbook Air M1.