### PR TITLE
fix: allocate collections in bump allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "ast_node"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +71,9 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "cc"
@@ -98,6 +107,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 name = "dprint-swc-ext"
 version = "0.14.1"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
  "num-bigint",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "rs-lib",
 ]

--- a/generation/generate/helpers.ts
+++ b/generation/generate/helpers.ts
@@ -48,10 +48,18 @@ export function writeType(writer: Writer, analysisResult: AnalysisResult, type: 
       writer.write(path);
       writer.write("<'a>");
     } else if (type.genericArgs.length > 0) {
-      writer.write(path);
-      writer.write("<");
+      if (path === "Vec") {
+        writer.write("&'a [");
+      } else {
+        writer.write(path);
+        writer.write("<");
+      }
       writer.write(type.genericArgs.map(type => writeType(writer, analysisResult, type, writeStructReference)).join(", "));
-      writer.write(">");
+      if (path === "Vec") {
+        writer.write("]");
+      } else {
+        writer.write(">");
+      }
     } else {
       writer.write(path);
     }

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -14,7 +14,8 @@ sourcemap = ["swc_common/sourcemap"]
 view = []
 
 [dependencies]
-bumpalo = "3.14.0"
+allocator-api2 = "0.2.16"
+bumpalo = { version = "3.14.0", features = ["collections", "allocator-api2"] }
 num-bigint = "0.4"
 rustc-hash = "1.1.0"
 swc_atoms = "0.6.5"

--- a/rs-lib/src/view/mod.rs
+++ b/rs-lib/src/view/mod.rs
@@ -8,7 +8,6 @@ mod test_helpers;
 #[rustfmt::skip]
 mod generated;
 
-pub use custom::*;
 pub use generated::*;
 pub use types::*;
 


### PR DESCRIPTION
Fixes a memory leak where collections weren't being deallocated.

Co-authored-by: irbull <irbull@users.noreply.github.com>