### PR TITLE
chore: add repository attribute to Cargo.toml

### DIFF
--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 license = "MIT"
 description = "Functionality to make swc easier to work with."
+repository = "https://github.com/dprint/dprint-swc-ext"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Found while scraping the top 5000 most recently downloaded crates from crates.io