### PR TITLE
fix: ensure safe text slicing boundaries with multi-byte characters

### DIFF
--- a/rs-lib/src/common/text_info.rs
+++ b/rs-lib/src/common/text_info.rs
@@ -187,7 +187,11 @@ impl SourceTextInfo {
   pub fn range_text(&self, range: &SourceRange) -> &str {
     let start = self.get_relative_index_from_pos(range.start);
     let end = self.get_relative_index_from_pos(range.end);
-    &self.text_str()[start..end]
+    let text = self.text_str();
+    let char_indices: Vec<_> = text.char_indices().collect();
+    let start_char_idx = char_indices.iter().position(|&(i, _)| i == start).unwrap_or(0);
+    let end_char_idx = char_indices.iter().position(|&(i, _)| i == end).unwrap_or(char_indices.len() - 1);
+    &text[char_indices[start_char_idx].0..char_indices[end_char_idx].0]
   }
 
   fn assert_pos(&self, pos: SourcePos) {


### PR DESCRIPTION
This commit resolves a panic that occurs when the text_info function attempts to slice a string containing non-ASCII characters.

The fix addresses the issue reported in the Deno repository: https://github.com/denoland/deno/issues/23875

**Use Case:**
The bug arises because the range_text method tries to slice a string using byte indices (start and end) that may not align with UTF-8 character boundaries. In Rust, attempting to slice a string at invalid UTF-8 boundaries results in a panic.

**Solution:**
The solution involves modifying the range_text method to correctly handle non-ASCII characters. The method now uses char_indices() to collect character boundaries and maps the start and end byte indices to these boundaries. The resulting string slice is based on valid UTF-8 character boundaries, ensuring the operation is safe and the encoding remains intact.