### PR TITLE
fix: revert rust 2024

### DIFF
--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dprint-swc-ext"
 version = "0.22.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
-edition = "2024"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/dprint/dprint-swc-ext"
 description = "Functionality to make swc easier to work with."


### PR DESCRIPTION
I didn't realize this was viral. Would be better to do this at a higher level first.